### PR TITLE
Do not declare compatibility to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 sudo: false
 php:
+  - 7.1
   - 7.0
   - 5.6
   - 5.5

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "flow/jsonpath": "^0.3.1",
-        "phpunit/phpunit": ">=4.8",
+        "phpunit/phpunit": ">=4.8,<6.0",
         "justinrainbow/json-schema": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Until now, the `composer.json` declares this package to be compatible with PHPUnit 6 (`>= 4.8`), which it is not.