### PR TITLE
Enhanced error message with JSON schema assertion

### DIFF
--- a/src/Constraint/JsonValueMatchesSchema.php
+++ b/src/Constraint/JsonValueMatchesSchema.php
@@ -70,7 +70,7 @@ class JsonValueMatchesSchema extends Constraint
         $validator->check($other, $this->schema);
 
         return implode("\n", array_map(function ($error) {
-            return $error['message'];
+            return sprintf("[%s] %s", $error['property'], $error['message']);
         }, $validator->getErrors()));
     }
 


### PR DESCRIPTION
The current error message is not descriptive enough to help with debugging against a json schema.
It would be very helpful to when a unit test fails to see exactly what property fails. This PR adds the property field to the error response as shown in the example from https://github.com/justinrainbow/json-schema 