### PR TITLE
Updated rainbow version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "flow/jsonpath": "^0.3.1",
         "phpunit/phpunit": ">=6.0",
-        "justinrainbow/json-schema": "5.2.1",
+        "justinrainbow/json-schema": "^5.0",
         "php": ">=7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "flow/jsonpath": "^0.3.1",
         "phpunit/phpunit": ">=6.0",
-        "justinrainbow/json-schema": "^2.0",
+        "justinrainbow/json-schema": "5.2.1",
         "php": ">=7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Updated the version of json-schema to the latest major version.

This adds support for `$refs` in json schema documents specified in the `draft-04` specification.

Ran PHPUnit test and they all passed.