### PR TITLE
Lock phpunit to v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "flow/jsonpath": "^0.3.1",
-        "phpunit/phpunit": ">=7.0",
+        "phpunit/phpunit": "^6.0",
         "justinrainbow/json-schema": "^5.0",
         "php": ">=7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "flow/jsonpath": "^0.3.1",
-        "phpunit/phpunit": ">=6.0",
+        "phpunit/phpunit": ">=7.0",
         "justinrainbow/json-schema": "^5.0",
         "php": ">=7.0"
     },


### PR DESCRIPTION
 v7 is incompatible with current master.

Will need to tag 2.0.1 after merging this and before my next PR that adds phpunit 7 compat or any new phpunit installs using this will break.