### PR TITLE
BC break: phpunit 7 is backwards incompatible with phpunit 6 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 sudo: false
 php:
   - 7.1
-  - 7.0
+  - 7.2
 install:
   - composer install --prefer-dist
 script:

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "flow/jsonpath": "^0.3.1",
-        "phpunit/phpunit": ">=6.0",
+        "phpunit/phpunit": "^7.0",
         "justinrainbow/json-schema": "^5.0",
-        "php": ">=7.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "dev-master"


### PR DESCRIPTION
and also requires php 7.1
As this will require bumping to the next major version, I'd recommend you merge #13 first, tag 2.0.1, then merge this and tag as 3.0.