### PR TITLE
Add support for PHPUnit 9 + migrate to Github Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,40 @@
+name: PHP type checking and unit testing
+
+on: [push]
+
+jobs:
+  build:
+    strategy:      
+      matrix:
+        php: ['7.2', '7.3', '7.4']
+        phpunit: ['8.0', '9.0']
+        exclude:
+          - php: '7.2'
+            phpunit: '9.0'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v1
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: mbstring, intl, json
+        coverage: pcov
+    
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Declare required PHPUnit version
+      run: |
+        composer require --no-update --dev phpunit/phpunit ~${{ matrix.phpunit }}
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    #- name: Run type checker
+    #  run: ./vendor/bin/psalm
+      
+    - name: Run unit tests
+      run: ./vendor/bin/phpunit --testdox

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ This library is [MIT-licensed](LICENSE.txt).
 
 There are several release branches of this library, each of these being compatible with different releases of PHPUnit and PHP. The following table should give an easy overview:
 
-| "JSON assertion" version | PHPUnit 4 | PHPUnit 5 | PHPUnit 6 | PHPUnit 7 | PHPUnit 8 |
-| ------------------------ | --------- | --------- | --------- | --------- | --------- |
-| v1 (branch `v1`), **unsupported** | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: |
-| v2 (branch `v2`) | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: | :no_entry_sign: |
-| v3 (branch `master`) | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: |
+| "JSON assertion" version | PHPUnit 4 | PHPUnit 5 | PHPUnit 6 | PHPUnit 7 | PHPUnit 8 | PHPUnit 9 |
+| ------------------------ | --------- | --------- | --------- | --------- | --------- | --------- |
+| v1 (branch `v1`), **unsupported** | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: |
+| v2 (branch `v2`) | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: |
+| v3 (branch `master`) | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: |
 
 When you are using `composer require` and have already declared a dependency to `phpunit/phpunit` in your `composer.json` file, Composer should pick latest compatible version automatically.
 

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,15 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^7.3",
         "flow/jsonpath": "^0.5.0",
         "justinrainbow/json-schema": "^5.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<8.0 || >= 9.0"
+        "phpunit/phpunit": "<8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^7.3",
+        "php": "^7.2",
         "flow/jsonpath": "^0.5.0",
         "justinrainbow/json-schema": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     },
     "autoload-dev": {
         "files": [
-            "vendor/phpunit/phpunit/src/Framework/Assert/Functions.php",
             "src/Functions.php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "justinrainbow/json-schema": "^5.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<8.0"
+        "phpunit/phpunit": "<8.0 || >= 10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0"

--- a/tests/Functional/JsonValueMatchesFluentTest.php
+++ b/tests/Functional/JsonValueMatchesFluentTest.php
@@ -2,10 +2,6 @@
 namespace Helmich\JsonAssert\Tests\Functional;
 
 use PHPUnit\Framework\TestCase;
-use function PHPUnit\Framework\assertThat;
-use function PHPUnit\Framework\equalTo;
-use function PHPUnit\Framework\greaterThanOrEqual;
-use function PHPUnit\Framework\logicalNot;
 
 class JsonValueMatchesFluentTest extends TestCase
 {
@@ -32,18 +28,18 @@ class JsonValueMatchesFluentTest extends TestCase
 
     public function testAssertThatJsonDocumentContainsJsonValue()
     {
-        assertThat(self::$exampleDocument, containsJsonValue('$.identifier', 1234));
+        $this->assertThat(self::$exampleDocument, containsJsonValue('$.identifier', 1234));
     }
 
     public function testAssertThatJsonDocumentMatchesJsonConstraints()
     {
-        assertThat(
+        $this->assertThat(
             self::$exampleDocument,
             matchesJsonConstraints(
                 [
-                    '$.owner.name' => equalTo('Max Mustermann'),
-                    '$.products[*].identifier' => greaterThanOrEqual(500),
-                    '$.products[*].name' => logicalNot(equalTo('Weißbrot'))
+                    '$.owner.name' => $this->equalTo('Max Mustermann'),
+                    '$.products[*].identifier' => $this->greaterThanOrEqual(500),
+                    '$.products[*].name' => $this->logicalNot($this->equalTo('Weißbrot'))
                 ]
             )
         );

--- a/tests/Functional/JsonValueMatchesFluentTest.php
+++ b/tests/Functional/JsonValueMatchesFluentTest.php
@@ -28,18 +28,18 @@ class JsonValueMatchesFluentTest extends TestCase
 
     public function testAssertThatJsonDocumentContainsJsonValue()
     {
-        assertThat(self::$exampleDocument, containsJsonValue('$.identifier', 1234));
+        $this->assertThat(self::$exampleDocument, containsJsonValue('$.identifier', 1234));
     }
 
     public function testAssertThatJsonDocumentMatchesJsonConstraints()
     {
-        assertThat(
+        $this->assertThat(
             self::$exampleDocument,
             matchesJsonConstraints(
                 [
-                    '$.owner.name' => equalTo('Max Mustermann'),
-                    '$.products[*].identifier' => greaterThanOrEqual(500),
-                    '$.products[*].name' => logicalNot(equalTo('Weißbrot'))
+                    '$.owner.name' => $this->equalTo('Max Mustermann'),
+                    '$.products[*].identifier' => $this->greaterThanOrEqual(500),
+                    '$.products[*].name' => $this->logicalNot($this->equalTo('Weißbrot'))
                 ]
             )
         );

--- a/tests/Functional/JsonValueMatchesFluentTest.php
+++ b/tests/Functional/JsonValueMatchesFluentTest.php
@@ -2,6 +2,10 @@
 namespace Helmich\JsonAssert\Tests\Functional;
 
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+use function PHPUnit\Framework\greaterThanOrEqual;
+use function PHPUnit\Framework\logicalNot;
 
 class JsonValueMatchesFluentTest extends TestCase
 {
@@ -28,18 +32,18 @@ class JsonValueMatchesFluentTest extends TestCase
 
     public function testAssertThatJsonDocumentContainsJsonValue()
     {
-        $this->assertThat(self::$exampleDocument, containsJsonValue('$.identifier', 1234));
+        assertThat(self::$exampleDocument, containsJsonValue('$.identifier', 1234));
     }
 
     public function testAssertThatJsonDocumentMatchesJsonConstraints()
     {
-        $this->assertThat(
+        assertThat(
             self::$exampleDocument,
             matchesJsonConstraints(
                 [
-                    '$.owner.name' => $this->equalTo('Max Mustermann'),
-                    '$.products[*].identifier' => $this->greaterThanOrEqual(500),
-                    '$.products[*].name' => $this->logicalNot($this->equalTo('Weißbrot'))
+                    '$.owner.name' => equalTo('Max Mustermann'),
+                    '$.products[*].identifier' => greaterThanOrEqual(500),
+                    '$.products[*].name' => logicalNot(equalTo('Weißbrot'))
                 ]
             )
         );

--- a/tests/Functional/JsonValueMatchesSchemaFluentTest.php
+++ b/tests/Functional/JsonValueMatchesSchemaFluentTest.php
@@ -31,7 +31,7 @@ class JsonValueMatchesSchemaFluentTest extends TestCase
 
     public function testJsonDocumentMatchesSchema()
     {
-        assertThat(static::$exampleDocument, matchesJsonSchema([
+        $this->assertThat(static::$exampleDocument, matchesJsonSchema([
             'type'       => 'object',
             'required'   => ['identifier', 'owner', 'products'],
             'properties' => [
@@ -64,7 +64,7 @@ class JsonValueMatchesSchemaFluentTest extends TestCase
     {
         $this->expectException(AssertionFailedError::class);
 
-        assertThat(static::$exampleDocument, matchesJsonSchema([
+        $this->assertThat(static::$exampleDocument, matchesJsonSchema([
             'type' => 'object',
             'required' => ['foobar'],
             'properties' => [

--- a/tests/Functional/JsonValueMatchesSchemaFluentTest.php
+++ b/tests/Functional/JsonValueMatchesSchemaFluentTest.php
@@ -4,6 +4,7 @@ namespace Helmich\JsonAssert\Tests\Functional;
 use Helmich\JsonAssert\JsonAssertions;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertThat;
 
 class JsonValueMatchesSchemaFluentTest extends TestCase
 {
@@ -31,7 +32,7 @@ class JsonValueMatchesSchemaFluentTest extends TestCase
 
     public function testJsonDocumentMatchesSchema()
     {
-        $this->assertThat(static::$exampleDocument, matchesJsonSchema([
+        assertThat(static::$exampleDocument, matchesJsonSchema([
             'type'       => 'object',
             'required'   => ['identifier', 'owner', 'products'],
             'properties' => [
@@ -64,7 +65,7 @@ class JsonValueMatchesSchemaFluentTest extends TestCase
     {
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertThat(static::$exampleDocument, matchesJsonSchema([
+        assertThat(static::$exampleDocument, matchesJsonSchema([
             'type' => 'object',
             'required' => ['foobar'],
             'properties' => [

--- a/tests/Functional/JsonValueMatchesSchemaFluentTest.php
+++ b/tests/Functional/JsonValueMatchesSchemaFluentTest.php
@@ -4,7 +4,6 @@ namespace Helmich\JsonAssert\Tests\Functional;
 use Helmich\JsonAssert\JsonAssertions;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use function PHPUnit\Framework\assertThat;
 
 class JsonValueMatchesSchemaFluentTest extends TestCase
 {
@@ -32,7 +31,7 @@ class JsonValueMatchesSchemaFluentTest extends TestCase
 
     public function testJsonDocumentMatchesSchema()
     {
-        assertThat(static::$exampleDocument, matchesJsonSchema([
+        $this->assertThat(static::$exampleDocument, matchesJsonSchema([
             'type'       => 'object',
             'required'   => ['identifier', 'owner', 'products'],
             'properties' => [
@@ -65,7 +64,7 @@ class JsonValueMatchesSchemaFluentTest extends TestCase
     {
         $this->expectException(AssertionFailedError::class);
 
-        assertThat(static::$exampleDocument, matchesJsonSchema([
+        $this->assertThat(static::$exampleDocument, matchesJsonSchema([
             'type' => 'object',
             'required' => ['foobar'],
             'properties' => [


### PR DESCRIPTION
This PR supercedes #19 by @chq81 (original commits still included) featuring compatibility to both PHPUnit 8+9, and migration to Github Actions using a Matrix build.