### PR TITLE
Update JsonValueMatches.php

### DIFF
--- a/src/Constraint/JsonValueMatches.php
+++ b/src/Constraint/JsonValueMatches.php
@@ -75,7 +75,7 @@ class JsonValueMatches extends Constraint
 
         foreach ($result as $v) {
             if ($v instanceof JSONPath) {
-                $v = $v->data();
+                $v = $v->getData();
             }
 
             $singleMatchResult = $this->constraint->evaluate($v, '', true);


### PR DESCRIPTION
`JSONPath::data` is deprecated in favor of `JSONPath::getData` and will be removed in [0.7.0](https://github.com/SoftCreatR/JSONPath/tree/0.7.0#070).