### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "softcreatr/jsonpath": "^0.6.2",
+        "softcreatr/jsonpath": "^0.6.4",
         "justinrainbow/json-schema": "^5.0"
     },
     "conflict": {


### PR DESCRIPTION
Bump `softcreatr/jsonpath` to `0.6.4`

You may also create a new Tag, so people don't need to add the new jsonpath package as a requirement in order to override the original package.