### PR TITLE
Fix broken PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,9 +13,6 @@
         <testsuite name="functional">
             <directory>tests/Functional</directory>
         </testsuite>
-        <testsuite name="unit">
-            <directory>tests/Unit</directory>
-        </testsuite>
     </testsuites>
     <logging>
         <log type="coverage-html" target="build/coverage" lowUpperBound="35"


### PR DESCRIPTION
Fixes breaking tests on master due to a bad PHPUnit configuration.
There is (and never was) a `Unit` test suite.