### PR TITLE
🐛 Fix for json path expecting an array

### DIFF
--- a/src/Constraint/JsonValueMatches.php
+++ b/src/Constraint/JsonValueMatches.php
@@ -62,7 +62,7 @@ class JsonValueMatches extends Constraint
     protected function matches($other): bool
     {
         if (is_string($other)) {
-            $other = json_decode($other);
+            $other = json_decode($other, true);
         }
 
         $result = (new JSONPath($other))->find($this->jsonPath);

--- a/tests/Functional/JsonValueMatchesTest.php
+++ b/tests/Functional/JsonValueMatchesTest.php
@@ -47,6 +47,14 @@ class JsonValueMatchesTest extends TestCase
             array($json, '$.products[*].name', 'Roggenbrot'),
             array($json, '$.products[0].name', 'Roggenbrot'),
             array($json, '$.products.*.name', 'Graubrot'),
+            array($json, '$.owner', [
+                'identifier' => '4321',
+                'name' => 'Max Mustermann',
+            ]),
+            array(json_encode($json), '$.owner', [
+                'identifier' => '4321',
+                'name' => 'Max Mustermann',
+            ]),
         ];
     }
 
@@ -64,6 +72,8 @@ class JsonValueMatchesTest extends TestCase
             array($json, '$.owner.name', 'Horst Mustermann'),
             array($json, '$.products.*.name', 'Weißbrot'),
             array($json, '$.products[0].name', 'Graubrot'),
+            array($json, '$.owner', []),
+            array(json_encode($json), '$.owner', []),
         ];
     }
 


### PR DESCRIPTION
The recent update to `softcreatr/jsonpath` introduced a type error if the asserted path returned a hash, as `getData()` declares `array` as the return type. 

I believe simple assertions worked because the top level object was being cast into an array, and traversing as an array worked, but if any specific path returned an object you'd get a type error due to the new return type declaration.