### PR TITLE
Actionable error message for large json documents

### DIFF
--- a/src/Constraint/JsonValueMatchesMany.php
+++ b/src/Constraint/JsonValueMatchesMany.php
@@ -69,7 +69,7 @@ class JsonValueMatchesMany extends Constraint
 
     /**
      * Returns a string representation of matches that evaluate to false.
-     * 
+     *
      * @return string
      */
     protected function additionalFailureDescription($other): string

--- a/src/Constraint/JsonValueMatchesMany.php
+++ b/src/Constraint/JsonValueMatchesMany.php
@@ -17,6 +17,9 @@ class JsonValueMatchesMany extends Constraint
     /** @var JsonValueMatches[] */
     private $constraints = array();
 
+    /** @var string[] */
+    private $failedConstraints = array();
+
     /**
      * JsonValueMatchesMany constructor.
      *
@@ -59,11 +62,23 @@ class JsonValueMatchesMany extends Constraint
      */
     protected function matches($other): bool
     {
+        $result = true;
         foreach ($this->constraints as $constraint) {
             if (!$constraint->evaluate($other, '', true)) {
-                return false;
+                $result = false;
+                $this->failedConstraints[] = $constraint->toString();
             }
         }
-        return true;
+        return $result;
+    }
+
+    /**
+     * Returns a string representation of matches that evaluate to false.
+     * 
+     * @return string
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        return "\n" . implode("\n", $this->failedConstraints);
     }
 }

--- a/src/Constraint/JsonValueMatchesMany.php
+++ b/src/Constraint/JsonValueMatchesMany.php
@@ -17,9 +17,6 @@ class JsonValueMatchesMany extends Constraint
     /** @var JsonValueMatches[] */
     private $constraints = array();
 
-    /** @var string[] */
-    private $failedConstraints = array();
-
     /**
      * JsonValueMatchesMany constructor.
      *
@@ -62,14 +59,12 @@ class JsonValueMatchesMany extends Constraint
      */
     protected function matches($other): bool
     {
-        $result = true;
         foreach ($this->constraints as $constraint) {
             if (!$constraint->evaluate($other, '', true)) {
-                $result = false;
-                $this->failedConstraints[] = $constraint->toString();
+                return false;
             }
         }
-        return $result;
+        return true;
     }
 
     /**
@@ -79,6 +74,15 @@ class JsonValueMatchesMany extends Constraint
      */
     protected function additionalFailureDescription($other): string
     {
-        return "\n" . implode("\n", $this->failedConstraints);
+        /** @var string[] */
+        $failedConstraints = array();
+
+        foreach ($this->constraints as $constraint) {
+            if (!$constraint->evaluate($other, '', true)) {
+                $failedConstraints[] = $constraint->toString();
+            }
+        }
+        
+        return "\n" . implode("\n", $failedConstraints);
     }
 }


### PR DESCRIPTION
### Problem

When using `assertJsonDocumentMatches`, it is hard to navigate the error message when the assertion fails.

The message only states that the given JSON document is not a match of the provided constraints.
It would be great to also tell _which constraint(s)_ the JSON document fails to satisfy.

### Solution

I implement `additionalFailureDescription` in `JsonValueMatchesMany` constraint to return a string representation of constraints that fail during evaluations.

The result would look like this.

<img width="1920" alt="Screen Shot 2564-03-21 at 07 41 33" src="https://user-images.githubusercontent.com/4034609/111890370-49b0b680-8a1b-11eb-98bb-e015bbcf0a84.png">

I think this would greatly simplify investigation when the tests fail.

Thank you