### PR TITLE
Update CI pipline and test on PHP version 8.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v1
       
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, intl, json

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, intl, json
+        ini-values: error_reporting=E_ALL
         coverage: pcov
         tools: composer:v2
     - name: Validate composer.json and composer.lock

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,20 +12,15 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
         phpunit: ['8.0', '9.0']
         composer-arg: ['']
-        include:
-          - php: '8.0'
-            phpunit: '9.0'
-            composer-arg: 'ignore-platform-req=php'
         exclude:
           - php: '8.0'
             phpunit: '8.0'
           - php: '7.2'
             phpunit: '9.0'
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.0' }}
     name: PHP ${{ matrix.php }}, PHPUnit ${{ matrix.phpunit }}
     
     steps:

--- a/.github/workflows/php_coverage.yml
+++ b/.github/workflows/php_coverage.yml
@@ -22,7 +22,7 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
   
     - name: Test & publish code coverage
-      uses: paambaati/codeclimate-action@v2.3.0
+      uses: paambaati/codeclimate-action@v3.0.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.codeClimateReporterID }}
       with:

--- a/.github/workflows/php_coverage.yml
+++ b/.github/workflows/php_coverage.yml
@@ -12,9 +12,9 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.0
         extensions: mbstring, intl, json
         coverage: pcov
     

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "softcreatr/jsonpath": "^0.7.2",
+        "softcreatr/jsonpath": "^0.7.2 || ^0.8",
         "justinrainbow/json-schema": "^5.0"
     },
     "conflict": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
+        convertDeprecationsToExceptions="true"
         timeoutForSmallTests="1"
         timeoutForMediumTests="10"
         timeoutForLargeTests="60">


### PR DESCRIPTION
I've also added config to make tests fail in case there are deprecation notices.