### PR TITLE
Update jsonpath library to get rid of deprecations, drop php7

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,18 +12,9 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['8.0', '8.1']
         phpunit: ['8.0', '9.0']
         composer-arg: ['']
-        include:
-          - php: '8.0'
-            phpunit: '9.0'
-            composer-arg: 'ignore-platform-req=php'
-        exclude:
-          - php: '8.0'
-            phpunit: '8.0'
-          - php: '7.2'
-            phpunit: '9.0'
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.php == '8.0' }}
     name: PHP ${{ matrix.php }}, PHPUnit ${{ matrix.phpunit }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,6 @@ jobs:
         phpunit: ['8.0', '9.0']
         composer-arg: ['']
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.0' }}
     name: PHP ${{ matrix.php }}, PHPUnit ${{ matrix.phpunit }}
     
     steps:

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "softcreatr/jsonpath": "^0.7.2",
+        "php": "^8.0",
+        "softcreatr/jsonpath": "^0.8",
         "justinrainbow/json-schema": "^5.0"
     },
     "conflict": {


### PR DESCRIPTION
JSONPath lib got rid of some deprecations:
https://github.com/SoftCreatR/JSONPath/pull/74#issuecomment-1025795747

So it would be great to either upgrade to 0.8 and drop php7 support or at least allow both 0.7 and 0.8 versions.
I think dropping php7 in 2022 is fine.