### PR TITLE
Add support for PHPUnit 10

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.0', '8.1', '8.2']
-        phpunit: ['8.0', '9.0']
+        phpunit: ['8.0', '9.0', '10.0']
         composer-arg: ['']
     runs-on: ubuntu-latest
     name: PHP ${{ matrix.php }}, PHPUnit ${{ matrix.phpunit }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,9 @@ jobs:
       matrix:
         php: ['8.0', '8.1', '8.2']
         phpunit: ['8.0', '9.0', '10.0']
-        composer-arg: ['']
+        exclude:
+          - php: 8.0
+          - phpunit: 10.0
     runs-on: ubuntu-latest
     name: PHP ${{ matrix.php }}, PHPUnit ${{ matrix.phpunit }}
     
@@ -37,7 +39,7 @@ jobs:
         composer require --no-update --dev phpunit/phpunit ~${{ matrix.phpunit }}
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest --${{ matrix.composer-arg }}
+      run: composer install --prefer-dist --no-progress --no-suggest
 
     #- name: Run type checker
     #  run: ./vendor/bin/psalm

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,8 +15,8 @@ jobs:
         php: ['8.0', '8.1', '8.2']
         phpunit: ['8.0', '9.0', '10.0']
         exclude:
-          - php: 8.0
-          - phpunit: 10.0
+          - php: '8.0'
+            phpunit: '10.0'
     runs-on: ubuntu-latest
     name: PHP ${{ matrix.php }}, PHPUnit ${{ matrix.phpunit }}
     

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -45,4 +45,4 @@ jobs:
     #  run: ./vendor/bin/psalm
       
     - name: Run unit tests
-      run: ./vendor/bin/phpunit --testdox
+      run: ./vendor/bin/phpunit --testdox --no-coverage

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ This library is [MIT-licensed](LICENSE.txt).
 
 There are several release branches of this library, each of these being compatible with different releases of PHPUnit and PHP. The following table should give an easy overview:
 
-| "JSON assertion" version | PHPUnit 4 | PHPUnit 5 | PHPUnit 6 | PHPUnit 7 | PHPUnit 8 | PHPUnit 9 |
-| ------------------------ | --------- | --------- | --------- | --------- | --------- | --------- |
-| v1 (branch `v1`), **unsupported** | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: |
-| v2 (branch `v2`) | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: |
-| v3 (branch `master`) | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: |
+| "JSON assertion" version | PHPUnit 4 | PHPUnit 5 | PHPUnit 6 | PHPUnit 7 | PHPUnit 8 | PHPUnit 9 | PHPUnit 10 |
+| ------------------------ | --------- | --------- | --------- | --------- | --------- | --------- | ---------- |
+| v1 (branch `v1`), **unsupported** | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: |
+| v2 (branch `v2`) | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: |
+| v3 (branch `master`) | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 When you are using `composer require` and have already declared a dependency to `phpunit/phpunit` in your `composer.json` file, Composer should pick latest compatible version automatically.
 

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         "justinrainbow/json-schema": "^5.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<8.0 || >= 10.0"
+        "phpunit/phpunit": "<8.0 || >= 11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,27 @@
+<?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.1/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
         bootstrap="vendor/autoload.php"
         colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertDeprecationsToExceptions="true"
         timeoutForSmallTests="1"
         timeoutForMediumTests="10"
-        timeoutForLargeTests="60">
+        timeoutForLargeTests="60"
+        cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="functional">
             <directory>tests/Functional</directory>
         </testsuite>
     </testsuites>
     <logging>
-        <log type="coverage-html" target="build/coverage" lowUpperBound="35"
-             highLowerBound="70"/>
-        <log type="junit" target="build/phpunit"/>
+        <junit outputFile="build/phpunit"/>
     </logging>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/tests/Functional/JsonValueMatchesTest.php
+++ b/tests/Functional/JsonValueMatchesTest.php
@@ -33,7 +33,7 @@ class JsonValueMatchesTest extends TestCase
         ],
     ];
 
-    public function dataForJsonValueEquals()
+    public static function dataForJsonValueEquals()
     {
         $json = static::$exampleDocument;
 
@@ -58,7 +58,7 @@ class JsonValueMatchesTest extends TestCase
         ];
     }
 
-    public function dataForJsonValueEqualsCanFail()
+    public static function dataForJsonValueEqualsCanFail()
     {
         $json = static::$exampleDocument;
 


### PR DESCRIPTION
These changes add support for PHPUnit version 10.

I've changed the CI pipeline to not execute tests for PHPUnit 10 on PHP 8.0 because PHPUnit 10 requires the PHP version to be at least 8.1.

I've also updated PHPUnit configuration XML file as an invalid config file leads to a non-zero exit code on PHPUnit 10.

Fixes #51 