### PR TITLE
Update justinrainbow/json-schema dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.1",
         "softcreatr/jsonpath": "^0.8",
-        "justinrainbow/json-schema": "^5.0"
+        "justinrainbow/json-schema": "^5.0 || ^6.0"
     },
     "conflict": {
         "phpunit/phpunit": "<8.0 || >= 13.0"


### PR DESCRIPTION
This PR adds support for justinrainbow/json-schema >= 6.0 and keep the old version too. 
As BC breaks seems like not affect this project
